### PR TITLE
fix: help page content overflow

### DIFF
--- a/pages/help.vue
+++ b/pages/help.vue
@@ -6,7 +6,7 @@
         {{ item.navTitle || item.title }}
       </NuxtLink>
     </div>
-    <div class="shadow flex-1 max-w-256 flex flex-col p-4">
+    <div class="shadow flex-1 max-w-256 w-0 flex flex-col p-4">
       <NuxtPage />
     </div>
   </div>


### PR DESCRIPTION
帮助页面的内容在 X 方向溢出屏幕了。之前虽然有 `max-w` 的 trick，在我电脑上还是溢出了。

需要告诉 flex 这些内容是可以 shrink 的。