### PR TITLE
fix: markdown list style

### DIFF
--- a/assets/styles/global.css
+++ b/assets/styles/global.css
@@ -17,3 +17,11 @@ body {
 .btn:hover {
   @apply bg-pku-red bg-op-3.9;
 }
+
+.markdown-body ol {
+  @apply list-decimal;
+}
+
+.markdown-body ul {
+  @apply list-disc;
+}

--- a/assets/styles/global.css
+++ b/assets/styles/global.css
@@ -17,11 +17,3 @@ body {
 .btn:hover {
   @apply bg-pku-red bg-op-3.9;
 }
-
-.markdown-body ol {
-  @apply list-decimal;
-}
-
-.markdown-body ul {
-  @apply list-disc;
-}

--- a/assets/styles/markdown.css
+++ b/assets/styles/markdown.css
@@ -1,0 +1,9 @@
+@import 'github-markdown-css/github-markdown-light.css';
+
+.markdown-body ol {
+  @apply list-decimal;
+}
+
+.markdown-body ul {
+  @apply list-disc;
+}

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -42,5 +42,5 @@
 </template>
 
 <script setup lang="ts">
-import 'github-markdown-css/github-markdown-light.css'
+import '@/assets/styles/markdown.css'
 </script>

--- a/pages/help/[...slug].vue
+++ b/pages/help/[...slug].vue
@@ -24,7 +24,7 @@
 </template>
 
 <script setup lang="ts">
-import 'github-markdown-css/github-markdown-light.css'
+import '@/assets/styles/markdown.css'
 import { IVariableConfig } from '@/lib/variables'
 
 const route = useRoute()


### PR DESCRIPTION
Markdown 列表的样式之前被 reset 了，我把它加了回来。比如 OpenSUSE 的帮助文档里就有用到列表。

之所以放 global 是考虑到其他地方也会用到一些 markdown，不过如果需要的话也可以考虑单写一个 Markdown 的 CSS 文件。