### PR TITLE
fix: AppSelect z-index

### DIFF
--- a/components/AppSelect.vue
+++ b/components/AppSelect.vue
@@ -11,7 +11,7 @@
     <ul
       v-show="showPop"
       ref="selectPop"
-      class="pos-absolute z-10 bg-white mx-1 border border-solid border-rounded border-color-[#d4d4d4]"
+      class="pos-absolute z-9 bg-white mx-1 border border-solid border-rounded border-color-[#d4d4d4]"
     >
       <li
         v-for="option in options"


### PR DESCRIPTION
Fix the bug of AppSelect rendering above the header bar.

Now:
![image](https://user-images.githubusercontent.com/21151119/227689757-5201fe66-af76-4476-a51f-4f40a86e9166.png)
